### PR TITLE
Create xmtpd API service

### DIFF
--- a/terraform/aws/fargate-task-definition/main.tf
+++ b/terraform/aws/fargate-task-definition/main.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_task_definition" "task" {
         }]
         portMappings = local.port_mappings
         # Default values that must be set to avoid re-creation
-        cpu = 0
+        cpu         = 0
         volumesFrom = []
         ulimits = [
           {

--- a/terraform/aws/xmtpd-api/_variables.tf
+++ b/terraform/aws/xmtpd-api/_variables.tf
@@ -1,0 +1,80 @@
+variable "cpu" {
+  description = "Available CPU for the replication server container"
+  default     = 1024
+}
+
+variable "memory" {
+  description = "Available memory for the replication server container"
+  default     = 2048
+}
+
+variable "docker_image" {
+  description = "xmtpd docker image"
+}
+
+variable "cluster_id" {
+  description = "The ID of the ECS cluster"
+}
+
+variable "private_subnets" {
+  description = "Private subnets to deploy the service into"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "Public subnets to deploy LB into"
+  type        = list(string)
+}
+
+variable "env" {
+  description = "The environment we're deploying to"
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the service"
+}
+
+variable "certificate_arn" {
+  description = "The ARN of the certificate to attach to the listener"
+  nullable    = true
+  type        = string
+  default     = null
+}
+
+variable "elb_logs_bucket_name" {
+  description = "Where to store ELB logs"
+  sensitive   = true
+  nullable    = true
+  type        = string
+  default     = null
+}
+
+variable "service_config" {
+  description = "Environment variables to pass to the service that are not sensitive"
+  type = object({
+    validation_service_grpc_address   = string
+    chain_id                          = string
+    nodes_contract_address            = string
+    messages_contract_address         = string
+    identity_updates_contract_address = string
+  })
+}
+
+variable "service_secrets" {
+  description = "Environment variables to pass to the service"
+  sensitive   = true
+  type = object({
+    database_url       = string
+    signer_private_key = string
+    chain_rpc_url      = string
+  })
+}
+
+variable "enable_debug_logs" {
+  description = "Enable debug logs for XMTPD server"
+}
+
+variable "desired_instance_count" {
+  description = "Desired number of instances to run"
+  default     = 2
+}

--- a/terraform/aws/xmtpd-api/load-balancer.tf
+++ b/terraform/aws/xmtpd-api/load-balancer.tf
@@ -1,0 +1,52 @@
+locals {
+  lb_type           = "application"
+  access_log_prefix = "xmtpd-access-logs"
+}
+
+resource "aws_lb" "public" {
+  name_prefix        = "xmtpd-"
+  internal           = false
+  load_balancer_type = local.lb_type
+  subnets            = var.public_subnets
+  security_groups    = [aws_security_group.load_balancer.id]
+
+  dynamic "access_logs" {
+    for_each = toset(var.elb_logs_bucket_name != null ? ["enabled"] : [])
+    content {
+      bucket  = var.elb_logs_bucket_name
+      prefix  = local.access_log_prefix
+      enabled = true
+    }
+  }
+}
+
+resource "aws_lb_listener" "public" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = local.public_port
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public.arn
+  }
+}
+
+resource "aws_lb_target_group" "public" {
+  depends_on       = [aws_lb.public]
+  name_prefix      = "xmtpd-"
+  port             = local.service_port
+  protocol         = "HTTP"
+  protocol_version = "GRPC"
+  target_type      = "ip"
+  vpc_id           = var.vpc_id
+
+  health_check {
+    path              = "/"
+    port              = local.service_port
+    interval          = 10
+    healthy_threshold = 2
+    matcher           = 12 // Check for a GRPC Unimplemented status which ensures that the GRPC server is running
+  }
+}

--- a/terraform/aws/xmtpd-api/main.tf
+++ b/terraform/aws/xmtpd-api/main.tf
@@ -1,0 +1,85 @@
+locals {
+  service_port = 5050
+  public_port  = 443
+  api_name     = "xmtpd-api"
+
+  // empty for now, all variables are provided via env
+  xmtp_node_command = concat([
+    # Turn on the metrics server (also required for health checks)
+    "--metrics.enable",
+    # Expose the metrics server to the DataDog docker container
+    "--metrics.metrics-address=0.0.0.0",
+    # Enable gRPC server reflection
+    "--reflection.enable",
+    # Enable the replication API
+    "--replication.enable",
+    # Make sure the port is set correctly
+    "--api.port=${local.service_port}"
+    ],
+    var.enable_debug_logs ? ["--log.log-level=debug"] : [],
+  )
+}
+
+#################################
+#########     API     ###########
+#################################
+
+module "api_task_definition" {
+  source = "../fargate-task-definition"
+  name   = local.api_name
+  cpu    = var.cpu
+  memory = var.memory
+
+  env_vars = {
+    "GOLOG_LOG_FMT"                            = "json"
+    "XMTPD_MLS_VALIDATION_GRPC_ADDRESS"        = var.service_config.validation_service_grpc_address
+    "XMTPD_CONTRACTS_CHAIN_ID"                 = var.service_config.chain_id
+    "XMTPD_CONTRACTS_NODES_ADDRESS"            = var.service_config.nodes_contract_address
+    "XMTPD_CONTRACTS_MESSAGES_ADDRESS"         = var.service_config.messages_contract_address
+    "XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS" = var.service_config.identity_updates_contract_address
+  }
+
+  secrets = {
+    "XMTPD_DB_WRITER_CONNECTION_STRING" = var.service_secrets.database_url
+    "XMTPD_SIGNER_PRIVATE_KEY"          = var.service_secrets.signer_private_key
+    "XMTPD_PAYER_PRIVATE_KEY"           = var.service_secrets.signer_private_key
+    "XMTPD_CONTRACTS_RPC_URL"           = var.service_secrets.chain_rpc_url
+  }
+
+  ports = [local.service_port]
+  image = var.docker_image
+  env   = var.env
+
+  command = local.xmtp_node_command
+
+  providers = {
+    aws = aws
+  }
+}
+
+resource "aws_ecs_service" "api" {
+  name                               = local.api_name
+  cluster                            = var.cluster_id
+  task_definition                    = module.api_task_definition.task_definition_arn
+  enable_execute_command             = false
+  desired_count                      = var.desired_instance_count
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+  wait_for_steady_state              = true
+
+  network_configuration {
+    subnets         = var.private_subnets
+    security_groups = [aws_security_group.ecs_service.id]
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 100
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.public.arn
+    container_name   = local.api_name
+    container_port   = local.service_port
+  }
+}

--- a/terraform/aws/xmtpd-api/security-groups.tf
+++ b/terraform/aws/xmtpd-api/security-groups.tf
@@ -1,0 +1,55 @@
+# The security group used for our xmtpd ECS services
+resource "aws_security_group" "ecs_service" {
+  name_prefix = "ecs-svc"
+  description = "xmtpd ECS service security group"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "egress" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  description       = "Allow all traffic to egress from ECS services"
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_service.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "lb_to_ecs" {
+  description              = "Allow traffic from load balancer to ECS service"
+  from_port                = local.service_port
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.ecs_service.id
+  source_security_group_id = aws_security_group.load_balancer.id
+  to_port                  = local.service_port
+  type                     = "ingress"
+}
+
+
+resource "aws_security_group" "load_balancer" {
+  name_prefix = "lb"
+  description = "Load balancer security group"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "lb_ingress" {
+  description       = "Allow https"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  from_port         = local.public_port
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_service.id
+  to_port           = local.public_port
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "lb_egress" {
+  description              = "Allow traffic from load balancer to ECS service"
+  from_port                = local.service_port
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.load_balancer.id
+  source_security_group_id = aws_security_group.ecs_service.id
+  to_port                  = local.service_port
+  type                     = "egress"
+}


### PR DESCRIPTION
## tl;dr

- Removes EFS mount support from the Fargate task definition module
- Creates a new public module for deploying the `xmtpd` API service with load balancer and security group configurations