### PR TITLE
Create xmtpd worker service

### DIFF
--- a/terraform/aws/xmtpd-worker/_variables.tf
+++ b/terraform/aws/xmtpd-worker/_variables.tf
@@ -1,0 +1,55 @@
+variable "cpu" {
+  description = "Available CPU for the replication server container"
+  default     = 1024
+}
+
+variable "memory" {
+  description = "Available memory for the replication server container"
+  default     = 2048
+}
+
+variable "docker_image" {
+  description = "xmtpd docker image"
+}
+
+variable "cluster_id" {
+  description = "The ID of the ECS cluster"
+}
+
+variable "public_subnets" {
+  description = "Public subnets to deploy LB into"
+  type        = list(string)
+}
+
+variable "env" {
+  description = "The environment we're deploying to"
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the service"
+}
+
+variable "service_config" {
+  description = "Environment variables to pass to the service that are not sensitive"
+  type = object({
+    validation_service_grpc_address   = string
+    chain_id                          = string
+    nodes_contract_address            = string
+    messages_contract_address         = string
+    identity_updates_contract_address = string
+  })
+}
+
+variable "service_secrets" {
+  description = "Environment variables to pass to the service"
+  sensitive   = true
+  type = object({
+    database_url       = string
+    signer_private_key = string
+    chain_rpc_url      = string
+  })
+}
+
+variable "enable_debug_logs" {
+  description = "Enable debug logs for XMTPD server"
+}

--- a/terraform/aws/xmtpd-worker/main.tf
+++ b/terraform/aws/xmtpd-worker/main.tf
@@ -1,0 +1,79 @@
+locals {
+  name         = "xmtpd-worker"
+  metrics_port = 8008
+
+  // empty for now, all variables are provided via env
+  xmtp_node_command = concat([
+    # Turn on the metrics server (also required for health checks)
+    "--metrics.enable",
+    # Expose the metrics server to the DataDog docker container
+    "--metrics.metrics-address=0.0.0.0",
+    # Expose the metrics server on the expected port
+    "--metrics.metrics-port=${local.metrics_port}",
+    # Enable the indexer 
+    "--indexer.enable",
+    # Enable the sync service
+    "--sync.enable"
+    ],
+    var.enable_debug_logs ? ["--log.log-level=debug"] : [],
+  )
+}
+
+
+module "task_definition" {
+  source = "../fargate-task-definition"
+  name   = local.name
+  cpu    = var.cpu
+  memory = var.memory
+
+  env_vars = {
+    "GOLOG_LOG_FMT"                            = "json"
+    "XMTPD_MLS_VALIDATION_GRPC_ADDRESS"        = var.service_config.validation_service_grpc_address
+    "XMTPD_CONTRACTS_CHAIN_ID"                 = var.service_config.chain_id
+    "XMTPD_CONTRACTS_NODES_ADDRESS"            = var.service_config.nodes_contract_address
+    "XMTPD_CONTRACTS_MESSAGES_ADDRESS"         = var.service_config.messages_contract_address
+    "XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS" = var.service_config.identity_updates_contract_address
+  }
+
+  secrets = {
+    "XMTPD_DB_WRITER_CONNECTION_STRING" = var.service_secrets.database_url
+    "XMTPD_SIGNER_PRIVATE_KEY"          = var.service_secrets.signer_private_key
+    "XMTPD_PAYER_PRIVATE_KEY"           = var.service_secrets.signer_private_key
+    "XMTPD_CONTRACTS_RPC_URL"           = var.service_secrets.chain_rpc_url
+  }
+
+  ports = []
+  image = var.docker_image
+  env   = var.env
+
+  command = local.xmtp_node_command
+
+  health_check_config = {
+    command = ["CMD-SHELL", "curl -f http://localhost:${local.metrics_port}"]
+  }
+
+  providers = {
+    aws = aws
+  }
+}
+
+resource "aws_ecs_service" "worker" {
+  name                               = local.name
+  cluster                            = var.cluster_id
+  task_definition                    = module.task_definition.task_definition_arn
+  enable_execute_command             = false
+  desired_count                      = 1
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+  wait_for_steady_state              = true
+
+  network_configuration {
+    subnets         = var.public_subnets
+    security_groups = [aws_security_group.ecs_service.id]
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 100
+  }
+}

--- a/terraform/aws/xmtpd-worker/security-group.tf
+++ b/terraform/aws/xmtpd-worker/security-group.tf
@@ -1,0 +1,17 @@
+# The security group used for our xmtpd ECS services
+resource "aws_security_group" "ecs_service" {
+  name_prefix = "wrkr"
+  description = "xmtpd ECS service security group"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "egress" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  description       = "Allow all traffic to egress from ECS services"
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_service.id
+  to_port           = 0
+  type              = "egress"
+}


### PR DESCRIPTION
### TL;DR
Added Terraform configuration for XMTPD worker service deployment on AWS ECS Fargate.

### What changed?
- Created new Terraform module for XMTPD worker service
- Configured ECS task definition with environment variables and secrets
- Set up security group rules for worker service networking
- Implemented health checks via metrics endpoint
- Added support for debug logging configuration
