### PR TITLE
Add TLS certificate configuration and public IP

### DIFF
--- a/terraform/aws/xmtpd-api/_outputs.tf
+++ b/terraform/aws/xmtpd-api/_outputs.tf
@@ -7,3 +7,8 @@ output "load_balancer_port" {
   description = "The port for the load balancer"
   value       = local.public_port
 }
+
+output "load_balancer_zone_id" {
+  description = "The zone ID for the load balancer"
+  value       = aws_lb.public.zone_id
+}

--- a/terraform/aws/xmtpd-worker/main.tf
+++ b/terraform/aws/xmtpd-worker/main.tf
@@ -67,8 +67,9 @@ resource "aws_ecs_service" "worker" {
   wait_for_steady_state              = true
 
   network_configuration {
-    subnets         = var.public_subnets # To avoid the NAT gateway we deploy the worker into the public subnets. This increases available bandwidth and reduces costs.
-    security_groups = [aws_security_group.ecs_service.id]
+    subnets          = var.public_subnets # To avoid the NAT gateway we deploy the worker into the public subnets. This increases available bandwidth and reduces costs.
+    security_groups  = [aws_security_group.ecs_service.id]
+    assign_public_ip = true
   }
 
   capacity_provider_strategy {

--- a/terraform/examples/aws-complete/_outputs.tf
+++ b/terraform/examples/aws-complete/_outputs.tf
@@ -16,3 +16,8 @@ output "api_load_balancer_address" {
   description = "The full address for the API load balancer"
   value       = module.xmtpd_api.load_balancer_address
 }
+
+output "api_domain_name" {
+  description = "The domain name for the API"
+  value       = var.domain_name
+}

--- a/terraform/examples/aws-complete/_variables.tf
+++ b/terraform/examples/aws-complete/_variables.tf
@@ -53,3 +53,8 @@ variable "signer_private_key" {
   sensitive   = true
   type        = string
 }
+
+variable "domain_name" {
+  description = "The domain name to use for public endpoints. This must have already been registered through AWS Route53 Domains"
+  type        = string
+}

--- a/terraform/examples/aws-complete/domain.tf
+++ b/terraform/examples/aws-complete/domain.tf
@@ -1,0 +1,75 @@
+
+# This domain must ALREADY BE REGISTERED in the AWS account.
+# Terraform will then take control of the registered domain
+resource "aws_route53domains_registered_domain" "public" {
+  domain_name = var.domain_name
+
+  # Enable auto-renewal
+  auto_renew = true
+
+  # Enable privacy protection
+  admin_privacy      = true
+  registrant_privacy = true
+  tech_privacy       = true
+
+  name_server {
+    name = aws_route53_zone.public.name_servers[0]
+  }
+
+  name_server {
+    name = aws_route53_zone.public.name_servers[1]
+  }
+}
+
+# Create a Route53 hosted zone for the domain
+resource "aws_route53_zone" "public" {
+  name = var.domain_name
+}
+
+# Create an ACM certificate for the domain
+resource "aws_acm_certificate" "public" {
+  depends_on        = [aws_route53domains_registered_domain.public]
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create DNS records for ACM certificate validation
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.public.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.public.zone_id
+}
+
+# Wait for certificate validation to complete
+resource "aws_acm_certificate_validation" "public" {
+  certificate_arn         = aws_acm_certificate.public.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# Create DNS record for the load balancer
+resource "aws_route53_record" "lb" {
+  zone_id = aws_route53_zone.public.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = module.xmtpd_api.load_balancer_address
+    zone_id                = module.xmtpd_api.load_balancer_zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
## tl;dr

- Adds a public IP to the worker so that it can connect to required AWS services like the secret manager (and other nodes)
- Adds TLS certificate configuration for a public domain
- Fixes subnets allowed to connect to the `mls_validation_service`

## Notes

The domain needs to be pre-registered through the AWS console. I haven't been able to make it work through automation. Once the domain is registered and the status has moved past pending Terraform will take control of the domain and register the name servers appropriately.