### PR TITLE
Split off the sync service

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
   go-lint-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/helm/README.md
+++ b/helm/README.md
@@ -62,7 +62,7 @@ helm install xmtpd xmtpd/ -f xmtpd.yaml
 
 ## Validating the installation
 
-Once you have successfully installed all charts, including a DB, you should see 6 pods running.
+Once you have successfully installed all charts, including a DB, you should see 4 pods running.
 You can confirm via:
 ```bash
 $ kubectl get pods
@@ -70,9 +70,7 @@ NAME                                      READY   STATUS    RESTARTS   AGE
 mls-validation-service-75b6b96f79-kp4jq   1/1     Running   0          6h30m
 pg-postgresql-0                           1/1     Running   0          6h26m
 xmtpd-api-7dd49f6b88-mfwls                1/1     Running   0          4h56m
-xmtpd-api-7dd49f6b88-xdk6k                1/1     Running   0          4h56m
 xmtpd-sync-7dd49f6b88-dn28d               1/1     Running   0          4h56m
-xmtpd-sync-7dd49f6b88-39axn               1/1     Running   0          4h56m
 ```
 
 ## XMTP Payer Helm Chart Installation

--- a/helm/README.md
+++ b/helm/README.md
@@ -62,15 +62,17 @@ helm install xmtpd xmtpd/ -f xmtpd.yaml
 
 ## Validating the installation
 
-Once you have successfully installed all charts, including a DB, you should see 4 pods running.
+Once you have successfully installed all charts, including a DB, you should see 6 pods running.
 You can confirm via:
 ```bash
 $ kubectl get pods
 NAME                                      READY   STATUS    RESTARTS   AGE
 mls-validation-service-75b6b96f79-kp4jq   1/1     Running   0          6h30m
 pg-postgresql-0                           1/1     Running   0          6h26m
-xmtpd-7dd49f6b88-mfwls                    1/1     Running   0          4h56m
-xmtpd-7dd49f6b88-xdk6k                    1/1     Running   0          4h56m
+xmtpd-api-7dd49f6b88-mfwls                1/1     Running   0          4h56m
+xmtpd-api-7dd49f6b88-xdk6k                1/1     Running   0          4h56m
+xmtpd-sync-7dd49f6b88-dn28d               1/1     Running   0          4h56m
+xmtpd-sync-7dd49f6b88-39axn               1/1     Running   0          4h56m
 ```
 
 ## XMTP Payer Helm Chart Installation

--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -37,6 +37,10 @@ spec:
           env:
             - name: XMTPD_REPLICATION_ENABLE
               value: "true"
+            - name: XMTPD_METRICS_ENABLE
+              value: "true"
+            - name: XMTPD_METRICS_METRICS_ADDRESS
+              value: "0.0.0.0"
             {{- include "helpers.list-env-variables" . | indent 12 }}
           ports:
             - name: grpc

--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "xmtpd.fullname" . }}-api
+  labels:
+    {{- include "xmtpd.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "xmtpd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "xmtpd.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "xmtpd.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: XMTPD_REPLICATION_ENABLE
+              value: "true"
+            {{- include "helpers.list-env-variables" . | indent 12 }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          startupProbe:
+            grpc:
+              port: {{ .Values.service.port }}
+            failureThreshold: 3
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: {{ .Values.service.port }}
+            failureThreshold: 3
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "xmtpd.fullname" . }}
+  name: {{ include "xmtpd.fullname" . }}-sync
   labels:
     {{- include "xmtpd.labels" . | nindent 4 }}
 spec:
@@ -35,27 +35,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: XMTPD_REPLICATION_ENABLE
-              value: "true"
             - name: XMTPD_SYNC_ENABLE
               value: "true"
             - name: XMTPD_INDEXER_ENABLE
               value: "true"
             {{- include "helpers.list-env-variables" . | indent 12 }}
-          ports:
-            - name: grpc
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
-          startupProbe:
-            grpc:
-              port: {{ .Values.service.port }}
-            failureThreshold: 3
-            periodSeconds: 10
-          livenessProbe:
-            grpc:
-              port: {{ .Values.service.port }}
-            failureThreshold: 3
-            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -39,7 +39,25 @@ spec:
               value: "true"
             - name: XMTPD_INDEXER_ENABLE
               value: "true"
+            - name: XMTPD_METRICS_ENABLE
+              value: "true"
+            - name: XMTPD_METRICS_METRICS_ADDRESS
+              value: "0.0.0.0"
             {{- include "helpers.list-env-variables" . | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8008
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8008
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/xmtpd/values.yaml
+++ b/helm/xmtpd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for xmtpd.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 2
+replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:

--- a/test/xmtp-helm/base_xmtpd_test.go
+++ b/test/xmtp-helm/base_xmtpd_test.go
@@ -32,5 +32,5 @@ func TestKubernetesBasicXMTPDInstall(t *testing.T) {
 	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_XMTPD)
-	testlib.StartXMTPD(t, &options, 2, namespace)
+	testlib.StartXMTPD(t, &options, 1, namespace)
 }


### PR DESCRIPTION
Separate deployment for the `sync` service. Same as the `api` service it has two replicas.

Enable the metrics endpoint for both.

Use the metrics endpoint as a readiness check for the `sync` api.