### PR TITLE
Helm improvements

### DIFF
--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -20,6 +20,8 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        app.kubernetes.io/role: api
+
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -44,16 +46,16 @@ spec:
             {{- include "helpers.list-env-variables" . | indent 12 }}
           ports:
             - name: grpc
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           startupProbe:
             grpc:
-              port: {{ .Values.service.port }}
+              port: {{ .Values.service.targetPort }}
             failureThreshold: 3
             periodSeconds: 10
           livenessProbe:
             grpc:
-              port: {{ .Values.service.port }}
+              port: {{ .Values.service.targetPort }}
             failureThreshold: 3
             periodSeconds: 10
           resources:

--- a/helm/xmtpd/templates/service.yaml
+++ b/helm/xmtpd/templates/service.yaml
@@ -8,7 +8,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
   selector:
     {{- include "xmtpd.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/role: api

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -20,6 +20,7 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        app.kubernetes.io/role: sync
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/xmtpd/values.yaml
+++ b/helm/xmtpd/values.yaml
@@ -48,9 +48,10 @@ securityContext: {}
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-  type: ClusterIP
+  type: LoadBalancer
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 5050
+  port: 80
+  targetPort: 5050
 
 resources: {}
   # limits:


### PR DESCRIPTION
- Both services got registered with the LB, which does not work. Use a specific selector to only select the API.
- Use a different port (by default 80) on the LB.
- use LB by default which exposes the service to the outside world

Tested in GKE and works as expected.