### PR TITLE
Force payer service to use 1 replica

### DIFF
--- a/helm/xmtp-payer/Chart.yaml
+++ b/helm/xmtp-payer/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 maintainers:
   - name: XMTPD
 version: 0.1.0
-appVersion: "v0.1.1"
+appVersion: "v0.1.3"

--- a/helm/xmtp-payer/templates/deployment.yaml
+++ b/helm/xmtp-payer/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "xmtp-payer.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "xmtp-payer.selectorLabels" . | nindent 6 }}
@@ -66,3 +66,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1

--- a/helm/xmtp-payer/values.yaml
+++ b/helm/xmtp-payer/values.yaml
@@ -4,7 +4,7 @@
 
 # we do not support more than 1 process with the same key
 # https://github.com/xmtp/xmtpd/issues/334
-#replicaCount: 1
+# replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:

--- a/helm/xmtp-payer/values.yaml
+++ b/helm/xmtp-payer/values.yaml
@@ -1,7 +1,10 @@
-# Default values for xmtpd.
+# Default values for Payer.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
+
+# we do not support more than 1 process with the same key
+# https://github.com/xmtp/xmtpd/issues/334
+#replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:

--- a/helm/xmtpd/Chart.yaml
+++ b/helm/xmtpd/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 maintainers:
   - name: XMTPD
 version: 0.1.0
-appVersion: "v0.1.1"
+appVersion: "v0.1.3"

--- a/test/testlib/objects.go
+++ b/test/testlib/objects.go
@@ -1,0 +1,99 @@
+package testlib
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"strings"
+	"testing"
+)
+
+func ExtractIngressE(t *testing.T, output string) *netv1.Ingress {
+	parts := strings.Split(output, "---")
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		if !strings.Contains(part, "kind: Ingress") {
+			continue
+		}
+
+		var object netv1.Ingress
+		helm.UnmarshalK8SYaml(t, part, &object)
+
+		return &object
+	}
+
+	return nil
+}
+
+func ExtractIngress(t *testing.T, output string) *netv1.Ingress {
+	ingress := ExtractIngressE(t, output)
+
+	if ingress == nil {
+		t.Fatalf("Could not extract ingress from template")
+	}
+
+	return ingress
+}
+
+func ExtractNamedSecretE(t *testing.T, output string, secretName string) *corev1.Secret {
+	parts := strings.Split(output, "---")
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		if !strings.Contains(part, "kind: Secret") {
+			continue
+		}
+
+		if !strings.Contains(part, fmt.Sprintf("name: %s", secretName)) {
+			continue
+		}
+
+		var object corev1.Secret
+		helm.UnmarshalK8SYaml(t, part, &object)
+
+		return &object
+	}
+
+	return nil
+}
+
+func ExtractDeploymentE(t *testing.T, output string, deploymentName string) *appsv1.Deployment {
+	parts := strings.Split(output, "---")
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		if !strings.Contains(part, "kind: Deployment") {
+			continue
+		}
+
+		if !strings.Contains(part, fmt.Sprintf("name: %s", deploymentName)) {
+			continue
+		}
+
+		var object appsv1.Deployment
+		helm.UnmarshalK8SYaml(t, part, &object)
+
+		return &object
+	}
+
+	return nil
+}
+
+func ExtractDeployment(t *testing.T, output string, deploymentName string) *appsv1.Deployment {
+	deployment := ExtractDeploymentE(t, output, deploymentName)
+
+	if deployment == nil {
+		t.Fatalf("Could not extract deployment from template")
+	}
+
+	return deployment
+}

--- a/test/testlib/xmtp_xmtpd.go
+++ b/test/testlib/xmtp_xmtpd.go
@@ -114,7 +114,6 @@ func getLastSection(envKey string) string {
 // 3. Default values.
 func GetDefaultSecrets(t *testing.T) map[string]string {
 	defaultSecrets := map[string]string{
-		"env.secret.XMTPD_DB_WRITER_CONNECTION_STRING":        "<replace-me>",
 		"env.secret.XMTPD_SIGNER_PRIVATE_KEY":                 "<replace-me>",
 		"env.secret.XMTPD_PAYER_PRIVATE_KEY":                  "<replace-me>",
 		"env.secret.XMTPD_CONTRACTS_RPC_URL":                  "https://rpc-testnet-staging-88dqtxdinc.t.conduit.xyz/",

--- a/test/xmtp-helm/base_payer_test.go
+++ b/test/xmtp-helm/base_payer_test.go
@@ -17,14 +17,7 @@ func TestKubernetesBasicPayerInstall(t *testing.T) {
 		SetValues: map[string]string{},
 	}
 
-	// technically the payer does NOT require a DB
-	// but XMTPD 0.1.1 has some incorrect defaults
-	// which will prevent the start of the service without DB connectivity
-	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
-	_, _, db := testlib.StartDB(t, &options, namespace)
-
 	secrets := testlib.GetDefaultSecrets(t)
-	secrets["env.secret.XMTPD_DB_WRITER_CONNECTION_STRING"] = db.ConnString
 
 	options = helm.Options{
 		SetValues: secrets,


### PR DESCRIPTION
Force the helm charts to only ever run 1 replica.

Some drive-by test cleanup.