### PR TITLE
Fix warning in Helm

### DIFF
--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -36,14 +36,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--replication.enable", "--metrics.enable", "--metrics.metrics-address=0.0.0.0"]
+          {{- if (include "helpers.list-env-variables" .) }}
           env:
-            - name: XMTPD_REPLICATION_ENABLE
-              value: "true"
-            - name: XMTPD_METRICS_ENABLE
-              value: "true"
-            - name: XMTPD_METRICS_METRICS_ADDRESS
-              value: "0.0.0.0"
-            {{- include "helpers.list-env-variables" . | indent 12 }}
+            {{ include "helpers.list-env-variables" . | indent 12 }}
+          {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.service.targetPort }}

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -35,16 +35,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--indexer.enable", "--sync.enable", "--metrics.enable", "--metrics.metrics-address=0.0.0.0" ]
+          {{- if (include "helpers.list-env-variables" .) }}
           env:
-            - name: XMTPD_SYNC_ENABLE
-              value: "true"
-            - name: XMTPD_INDEXER_ENABLE
-              value: "true"
-            - name: XMTPD_METRICS_ENABLE
-              value: "true"
-            - name: XMTPD_METRICS_METRICS_ADDRESS
-              value: "0.0.0.0"
-            {{- include "helpers.list-env-variables" . | indent 12 }}
+            {{ include "helpers.list-env-variables" . | indent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /metrics

--- a/test/xmtp-helm/template_xmtpd_test.go
+++ b/test/xmtp-helm/template_xmtpd_test.go
@@ -77,3 +77,29 @@ func TestXmtpdIngressTLSSecretNoCreate(t *testing.T) {
 	secret := testlib.ExtractNamedSecretE(t, output, "my-secret")
 	assert.Nil(t, secret)
 }
+
+func TestXmtpdNoEnvWorks(t *testing.T) {
+
+	options := &helm.Options{}
+
+	output := helm.RenderTemplate(t, options, testlib.XMTPD_HELM_CHART_PATH, "release-name", []string{})
+	deployment := testlib.ExtractDeployment(t, output, "release-name-xmtpd")
+
+	assert.NotNil(t, deployment)
+	assert.Empty(t, deployment.Spec.Template.Spec.Containers[0].Env)
+}
+
+func TestXmtpdEnvWorks(t *testing.T) {
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"env.secret.XMTPD_LOG_LEVEL": "debug",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, testlib.XMTPD_HELM_CHART_PATH, "release-name", []string{})
+	deployment := testlib.ExtractDeployment(t, output, "release-name-xmtpd")
+
+	assert.NotNil(t, deployment)
+	assert.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Env)
+}


### PR DESCRIPTION
Fix:
```
W0107 10:53:45.880709   72989 warnings.go:70] spec.template.spec.containers[0].env[11]: hides previous definition of "XMTPD_METRICS_ENABLE", which may be dropped when using apply
W0107 10:53:45.914361   72989 warnings.go:70] autopilot-default-resources-mutator:Autopilot updated Deployment default/xmtpd-api: defaulted unspecified 'cpu' resource for containers [xmtpd] (see http://g.co/gke/autopilot-defaults).
W0107 10:53:45.914435   72989 warnings.go:70] spec.template.spec.containers[0].env[10]: hides previous definition of "XMTPD_METRICS_ENABLE", which may be dropped when using apply
```

The cause was that we were hardcoding metrics and allowing the config to set them.

Metrics are used for the probes, so they should never be turned off by configuration