### PR TITLE
Fix parameter type

### DIFF
--- a/test/testlib/xmtp_xmtpd.go
+++ b/test/testlib/xmtp_xmtpd.go
@@ -36,7 +36,7 @@ func StartXMTPD(t *testing.T, options *helm.Options, replicaCount int, namespace
 
 type XMTPDInstallationStep func(t *testing.T, options *helm.Options, helmChartReleaseName string)
 
-func startXMTPDTemplate(t *testing.T, options *helm.Options, replicaCount int, namespace string, releaseName string, installStep MLSInstallationStep, awaitRunning bool) (helmChartReleaseName string, namespaceName string) {
+func startXMTPDTemplate(t *testing.T, options *helm.Options, replicaCount int, namespace string, releaseName string, installStep XMTPDInstallationStep, awaitRunning bool) (helmChartReleaseName string, namespaceName string) {
 	randomSuffix := strings.ToLower(random.UniqueId())
 
 	helmChartReleaseName = releaseName


### PR DESCRIPTION
In the code, the type XMTPDInstallationStep is defined for the XMTPD installation step, but the type MLSInstallationStep is used for the parameter in the startXMTPDTemplate function declaration.