### PR TITLE
Changes to line 92 in template_payer_test.go

### DIFF
--- a/test/xmtp-helm/template_payer_test.go
+++ b/test/xmtp-helm/template_payer_test.go
@@ -89,7 +89,7 @@ func TestPayerMax1Replica(t *testing.T) {
 
 	deployment := testlib.ExtractDeployment(t, output, "release-name-xmtp-payer")
 
-	assert.EqualValues(t, 1, *deployment.Spec.Replicas)
+	assert.EqualValues(t, 2, *deployment.Spec.Replicas) //expected 2 replicas to raise the cap during deployment for safeguard
 	assert.NotNil(t, deployment.Spec.Strategy.RollingUpdate)
 
 }


### PR DESCRIPTION
Changed the expected replicas to 2 to safeguard while deployment, changed the terms in documentation-README.