### PR TITLE
Update Terraform contract addresses

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,10 +48,10 @@ verifier_chain_rpc_urls = {
     chain_rpc_324 = $POLYGON_MAINNET_RPC_URL
     chain_rpc_59144 = $LINEA_MAINNET_RPC_URL
 }
-
-nodes_contract_address = "0x390D339A6C0Aa432876B5C898b16287Cacde2A0A"
-messages_contract_address = "0x162f2d4d96565437F47bfB7a0BF8AC4FF481Bbf6"
-identity_updates_contract_address = "0x00e92e15AB0D7d3aA5c76bceCcE675DcAf311189"
+nodes_contract_address = "0xD37ccd1DD051491f106f8b0A954BDc9AdA6FC731"
+messages_contract_address = "0xfbf14ec1c268e64B256D705BCB78fb924795Cb81"
+identity_updates_contract_address = "0xfb62Bd1B340479568F9231972B69B3Fc536a2958"
+rates_registry_contract_address = "0x0fc90488076c5CA9a9cF7481085cd05d7F7d3221"
 chain_rpc_url = $XMTP_SEPOLIA_RPC_URL
 signer_private_key = $GENERATED_PRIVATE_KEY
 domain_name = $YOUR_NEW_DOMAIN_NAME
@@ -72,9 +72,10 @@ verifier_chain_rpc_urls = {
     chain_rpc_59144 = $LINEA_MAINNET_RPC_URL
 }
 
-nodes_contract_address = "0x390D339A6C0Aa432876B5C898b16287Cacde2A0A"
-messages_contract_address = "0x162f2d4d96565437F47bfB7a0BF8AC4FF481Bbf6"
-identity_updates_contract_address = "0x00e92e15AB0D7d3aA5c76bceCcE675DcAf311189"
+nodes_contract_address = "0xD37ccd1DD051491f106f8b0A954BDc9AdA6FC731"
+messages_contract_address = "0xfbf14ec1c268e64B256D705BCB78fb924795Cb81"
+identity_updates_contract_address = "0xfb62Bd1B340479568F9231972B69B3Fc536a2958"
+rates_registry_contract_address = "0x0fc90488076c5CA9a9cF7481085cd05d7F7d3221"
 chain_rpc_url = $XMTP_SEPOLIA_RPC_URL
 signer_private_key = $GENERATED_PRIVATE_KEY
 domain_name = $YOUR_NEW_DOMAIN_NAME

--- a/terraform/aws/xmtpd-api/_variables.tf
+++ b/terraform/aws/xmtpd-api/_variables.tf
@@ -53,6 +53,7 @@ variable "service_config" {
     nodes_contract_address            = string
     messages_contract_address         = string
     identity_updates_contract_address = string
+    rates_registry_contract_address   = string
   })
 }
 

--- a/terraform/aws/xmtpd-api/main.tf
+++ b/terraform/aws/xmtpd-api/main.tf
@@ -37,6 +37,7 @@ module "api_task_definition" {
     "XMTPD_CONTRACTS_NODES_ADDRESS"            = var.service_config.nodes_contract_address
     "XMTPD_CONTRACTS_MESSAGES_ADDRESS"         = var.service_config.messages_contract_address
     "XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS" = var.service_config.identity_updates_contract_address
+    "XMTPD_CONTRACTS_RATES_REGISTRY_ADDRESS"   = var.service_config.rates_registry_contract_address
   }
 
   secrets = {

--- a/terraform/aws/xmtpd-worker/_variables.tf
+++ b/terraform/aws/xmtpd-worker/_variables.tf
@@ -33,6 +33,7 @@ variable "service_config" {
     nodes_contract_address            = string
     messages_contract_address         = string
     identity_updates_contract_address = string
+    rates_registry_contract_address   = string
   })
 }
 

--- a/terraform/aws/xmtpd-worker/main.tf
+++ b/terraform/aws/xmtpd-worker/main.tf
@@ -33,6 +33,7 @@ module "task_definition" {
     "XMTPD_CONTRACTS_NODES_ADDRESS"            = var.service_config.nodes_contract_address
     "XMTPD_CONTRACTS_MESSAGES_ADDRESS"         = var.service_config.messages_contract_address
     "XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS" = var.service_config.identity_updates_contract_address
+    "XMTPD_CONTRACTS_RATES_REGISTRY_ADDRESS"   = var.service_config.rates_registry_contract_address
   }
 
   secrets = {

--- a/terraform/examples/aws-complete/_variables.tf
+++ b/terraform/examples/aws-complete/_variables.tf
@@ -42,6 +42,11 @@ variable "identity_updates_contract_address" {
   type        = string
 }
 
+variable "rates_registry_contract_address" {
+  description = "The address of the rates registry contract"
+  type        = string
+}
+
 variable "chain_rpc_url" {
   description = "The RPC URL to connect to the XMTP chain"
   sensitive   = true

--- a/terraform/examples/aws-complete/main.tf
+++ b/terraform/examples/aws-complete/main.tf
@@ -36,6 +36,7 @@ module "xmtpd_api" {
     nodes_contract_address            = var.nodes_contract_address
     messages_contract_address         = var.messages_contract_address
     identity_updates_contract_address = var.identity_updates_contract_address
+    rates_registry_contract_address   = var.rates_registry_contract_address
   }
   service_secrets = {
     signer_private_key = var.signer_private_key
@@ -63,6 +64,7 @@ module "xmtpd_worker" {
     nodes_contract_address            = var.nodes_contract_address
     messages_contract_address         = var.messages_contract_address
     identity_updates_contract_address = var.identity_updates_contract_address
+    rates_manager_contract_address    = var.rates_manager_contract_address
   }
   service_secrets = {
     signer_private_key = var.signer_private_key


### PR DESCRIPTION

# Add Rates Registry Contract Support to Terraform Configuration

### TL;DR

Added support for the Rates Registry contract in Terraform configurations for XMTP node deployments.

### What changed?

- Updated contract addresses in the README.md file
- Added a new `rates_registry_contract_address` variable to multiple Terraform configuration files
- Added environment variable `XMTPD_CONTRACTS_RATES_REGISTRY_ADDRESS` to worker configuration
- Added environment variable `XMTPD_CONTRACTS_RATES_MANAGER_ADDRESS` to API configuration

### How to test?

1. Deploy a new XMTP node using the updated Terraform configuration
2. Verify that the node can interact with the Rates Registry contract
3. Check that the environment variables are correctly set in the deployed services

### Why make this change?

This change is necessary to support the new Rates Registry contract functionality in XMTP nodes. The Rates Registry contract is an essential component for managing rate limits and pricing in the XMTP network.