### PR TITLE
Allow concurrent startup of services

### DIFF
--- a/test/testlib/global.go
+++ b/test/testlib/global.go
@@ -123,3 +123,11 @@ func GetDefaultSecrets(t *testing.T) map[string]string {
 
 	return defaultSecrets
 }
+
+func RunAsync[T any](f func() T) <-chan T {
+	ch := make(chan T, 1)
+	go func() {
+		ch <- f()
+	}()
+	return ch
+}

--- a/test/xmtp-helm/base_payer_test.go
+++ b/test/xmtp-helm/base_payer_test.go
@@ -13,8 +13,18 @@ func TestKubernetesBasicPayerInstall(t *testing.T) {
 	options := helm.Options{
 		SetValues: map[string]string{},
 	}
-	_, _, db := testlib.StartDB(t, &options, namespace)
-	_, _, anvil := testlib.StartAnvil(t, &options, namespace)
+
+	dbCh := testlib.RunAsync(func() testlib.DB {
+		_, _, db := testlib.StartDB(t, &options, namespace)
+		return db
+	})
+	anvilCh := testlib.RunAsync(func() testlib.AnvilCfg {
+		_, _, anvil := testlib.StartAnvil(t, &options, namespace)
+		return anvil
+	})
+
+	db := <-dbCh
+	anvil := <-anvilCh
 
 	secrets := testlib.GetDefaultSecrets(t)
 	secrets["env.secret.XMTPD_DB_WRITER_CONNECTION_STRING"] = db.ConnString


### PR DESCRIPTION
### Implement concurrent service startup in Kubernetes test functions using new `RunAsync` generic function
* Adds new generic utility function `RunAsync[T any]` in [global.go](https://github.com/xmtp/xmtpd-infrastructure/pull/43/files#diff-a3b937f588540ab145346d83a4890eccfcaf4ef37ad2970b5e87ed96b5609a24) that executes functions asynchronously and returns results through channels
* Modifies [base_payer_test.go](https://github.com/xmtp/xmtpd-infrastructure/pull/43/files#diff-5e0b6c734615c861510fc320b58af4dff767efc55cb649b4bc588b7e0f041cd4) to run database and anvil services concurrently in `TestKubernetesBasicPayerInstall`
* Updates [base_xmtpd_test.go](https://github.com/xmtp/xmtpd-infrastructure/pull/43/files#diff-e8d7659dae7d9fdd75e11d1d34cc4eed109010c5507737358537623bd7c02dfa) to initialize database, MLS, and anvil services in parallel within `TestKubernetesBasicXMTPDInstall`

#### 📍Where to Start
Start with the `RunAsync` generic function implementation in [global.go](https://github.com/xmtp/xmtpd-infrastructure/pull/43/files#diff-a3b937f588540ab145346d83a4890eccfcaf4ef37ad2970b5e87ed96b5609a24), which provides the core functionality used by the modified test functions.

----

_[Macroscope](https://app.macroscope.com) summarized e94b075._