### PR TITLE
Fix env templating and enable metrics in Payer

### DIFF
--- a/helm/xmtp-payer/templates/deployment.yaml
+++ b/helm/xmtp-payer/templates/deployment.yaml
@@ -38,16 +38,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--payer.enable", "--metrics.enable", "--metrics.metrics-address=0.0.0.0"]
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
-            - name: XMTPD_PAYER_ENABLE
-              value: "true"
-            {{- include "helpers.list-env-variables" . | indent 12 }}
+          {{- if (include "helpers.list-env-variables" .) }}
+            {{ include "helpers.list-env-variables" . | indent 12 }}
+          {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+            - name: metrics
+              containerPort: 8008
           startupProbe:
             grpc:
               port: {{ .Values.service.targetPort }}

--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -40,10 +40,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["--replication.enable", "--metrics.enable", "--metrics.metrics-address=0.0.0.0"]
-          {{- if (include "helpers.list-env-variables" .) }}
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+          {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}
           ports:

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -40,10 +40,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["--indexer.enable", "--sync.enable", "--metrics.enable", "--metrics.metrics-address=0.0.0.0" ]
-          {{- if (include "helpers.list-env-variables" .) }}
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+          {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}
           ports:


### PR DESCRIPTION
### Fix env templating and enable metrics in Payer by switching from environment variables to command line arguments and adding metrics port 8008
- Modifies the Payer deployment to use command line arguments (`--payer.enable`, `--metrics.enable`, `--metrics.metrics-address`) instead of the `XMTPD_PAYER_ENABLE` environment variable in [deployment.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/48/files#diff-d025ce2784b75f1e26bb7dbf671e175f5fa379e7e8ba137fb2318e22fab34cee)
- Adds metrics port 8008 to the Payer container configuration in [deployment.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/48/files#diff-d025ce2784b75f1e26bb7dbf671e175f5fa379e7e8ba137fb2318e22fab34cee)
- Restructures environment variable templating in API and sync deployments to ensure `XMTPD_CONTRACTS_CONFIG_FILE_PATH` is always defined in [api.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/48/files#diff-eba6da1517853c53c01d4517e4dd26d2732bc7f60d0ccaff9c16144c8bdeeb89) and [sync.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/48/files#diff-7782a2310df44a533b5cb109d9f237d1bff10e71535c6f9fe541c656bc923db5)
- Makes environment variable inclusion from `helpers.list-env-variables` conditional across all affected templates

#### 📍Where to Start
Start with the container configuration changes in [deployment.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/48/files#diff-d025ce2784b75f1e26bb7dbf671e175f5fa379e7e8ba137fb2318e22fab34cee) to understand the shift from environment variables to command line arguments for the Payer service.

----

_[Macroscope](https://app.macroscope.com) summarized 70d3713._