### PR TITLE
Fix indent of prune cronjob helm template

### DIFF
--- a/helm/xmtpd/templates/cronjob.yaml
+++ b/helm/xmtpd/templates/cronjob.yaml
@@ -49,14 +49,14 @@ spec:
                   readOnly: true
           {{- with .Values.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
 {{- end }}


### PR DESCRIPTION
The helm template indentation of the prune cronjob was incorrectly set to 8 instead of 12 for the nodeSelector, affinity, and tolerations.