### PR TITLE
add unit files for systemd-based operation

### DIFF
--- a/systemd/mls-validation.service
+++ b/systemd/mls-validation.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=mls-validation-service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+ExecStart=/usr/local/bin/mls-validation-service
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/xmtpd-api.service
+++ b/systemd/xmtpd-api.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=xmtpd-api
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+EnvironmentFile=/etc/xmtpd.env
+ExecStart=/usr/local/bin/xmtpd --reflection.enable --replication.enable --log.log-level=debug --api.port=5050
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/xmtpd-prune.service
+++ b/systemd/xmtpd-prune.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=xmtpd-prune
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+EnvironmentFile=/etc/xmtpd.env
+ExecStart=/usr/local/bin/xmtpd-prune
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/xmtpd-worker.service
+++ b/systemd/xmtpd-worker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=xmtpd-worker
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+EnvironmentFile=/etc/xmtpd.env
+ExecStart=/usr/local/bin/xmtpd --indexer.enable --sync.enable --api.port=5060 --api.http-port=5065
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These are the relevant service units that may be useful for others who are also looking to run the system in a non k8s setting.

I can also add a readme with the structure of the env file, and process for building the binaries if useful.