### PR TITLE
Add SystemD README and sandbox for testing

### DIFF
--- a/dev/docker/build-systemd
+++ b/dev/docker/build-systemd
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+error() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+# Get the directory where the script is located
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+TOP_LEVEL_DIR=$(realpath "${SCRIPT_DIR}/../.." 2>/dev/null) || error "Failed to resolve top-level directory"
+
+[ -d "$TOP_LEVEL_DIR" ] || error "Top level directory not found: $TOP_LEVEL_DIR"
+
+cd "$TOP_LEVEL_DIR" || error "Failed to change to top level directory"
+
+DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-latest}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtpd-systemd}"
+
+docker buildx build \
+    --tag "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" \
+    -f dev/docker/systemd.Dockerfile \
+    .

--- a/dev/docker/run-systemd
+++ b/dev/docker/run-systemd
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker run --rm -d \
+  --name xmtpd-systemd \
+  --privileged \
+  --cgroupns=host \
+  --tmpfs /run \
+  --tmpfs /run/lock \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+  xmtpd-systemd

--- a/dev/docker/systemd.Dockerfile
+++ b/dev/docker/systemd.Dockerfile
@@ -1,0 +1,33 @@
+# systemd sandbox for xmtpd
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV XMTDP_VERSION=1.0.0
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      systemd \
+      ca-certificates \
+      curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Fetch xmtpd release tarball and install the binary
+RUN curl -L "https://github.com/xmtp/xmtpd/releases/download/v${XMTDP_VERSION}/xmtpd_${XMTDP_VERSION}_linux_amd64.tar.gz" \
+      -o /tmp/xmtpd.tar.gz && \
+    mkdir -p /usr/local/bin && \
+    tar -xzf /tmp/xmtpd.tar.gz \
+      -C /usr/local/bin \
+      --strip-components=1 \
+      "xmtpd_${XMTDP_VERSION}_linux_amd64/xmtpd" && \
+    chmod 0755 /usr/local/bin/xmtpd && \
+    rm -f /tmp/xmtpd.tar.gz
+
+# Fetch the testnet config file
+RUN mkdir -p /etc/xmtpd && \
+    curl -L "https://github.com/xmtp/smart-contracts/releases/download/v2025.12.03-1/testnet.json" \
+      -o /etc/xmtpd/testnet.json
+
+COPY systemd/ /etc/systemd/system/
+
+# Run systemd as PID 1
+CMD ["/lib/systemd/systemd"]

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,176 @@
+# XMTPD Systemd Integration
+
+This document explains how to run, test, and debug xmtpd using systemd.
+It supports:
+- Local sandbox testing via Docker
+- Production deployment on Linux systems using systemd
+
+The systemd configuration provided here supports xmtpd-api, xmtpd-workers, and pruner
+
+## Directory Structure
+```
+systemd/
+├── xmtpd-api.service
+├── xmtpd-prune.service
+├── xmtpd-worker.service
+dev/docker/systemd.Dockerfile
+xmtpd.env             (optional local env file)
+```
+
+Unit files in `systemd/` are copied into `/etc/systemd/system/` in the sandbox image.
+
+## Configuration Layout
+
+All configuration for xmtpd lives under:
+```
+/etc/xmtpd/
+xmtpd.env        # environment variables
+testnet.json     # contract configuration
+```
+
+Load the env file into your current shell
+```
+set -a
+. /etc/xmtpd/xmtpd.env
+set +a
+```
+
+Validate the config
+```
+env | grep XMTPD_
+cat /etc/xmtpd/testnet.json | head
+```
+
+## Building the Systemd Sandbox Image
+
+The sandbox image boots a real Ubuntu systemd instance and installs the xmtpd release, example systemd unit files, and testnet config.
+
+Build the image:
+```
+./dev/docker/build-systemd
+```
+
+Included in the image:
+- Ubuntu 24.04
+- systemd as PID 1
+- xmtpd v1.0.0 release binary
+- /etc/xmtpd/testnet.json from XMTP smart contracts
+- /etc/xmtpd/xmtpd.env if provided
+- All units from systemd/
+
+## Running the Systemd Sandbox
+
+To run systemd properly inside Docker, run
+```
+./dev/docker/run-systemd
+```
+
+This creates a fully booted Linux system inside Docker.
+
+Open a shell:
+```
+docker exec -it xmtpd-systemd bash
+```
+
+
+## Inspecting Systemd State
+### Verify systemd is PID 1
+
+```
+ps -p 1 -o pid,comm,args
+```
+
+Expected:
+```
+1 systemd /lib/systemd/systemd
+```
+
+### Overall system state
+```
+systemctl is-system-running
+```
+
+### List installed unit files
+```
+systemctl list-unit-files --no-pager
+```
+
+### List active services
+```
+systemctl list-units --type=service --no-pager
+```
+
+## Working with Units
+### Reload unit files
+```
+systemctl daemon-reload
+```
+
+### Start a service
+```
+systemctl start xmtpd-api.service
+systemctl status xmtpd-api.service --no-pager
+```
+
+### Stop a service
+```
+systemctl stop xmtpd-api.service
+```
+
+### Enable a service on boot
+```
+systemctl enable xmtpd-api.service
+```
+
+## Inspecting Logs
+
+View recent logs for a service:
+
+```
+journalctl -u xmtpd-api.service -n 50 --no-pager
+```
+
+View global logs:
+
+```
+journalctl -n 200 --no-pager
+```
+
+## Editing and Testing Unit Files
+
+1. Modify a file under systemd/ on the host
+2. Rebuild the sandbox image
+3. Run the container
+4. Test the unit:
+```
+systemctl cat xmtpd-api.service
+systemctl daemon-reload
+systemctl restart xmtpd-api.service
+systemctl status xmtpd-api.service --no-pager
+journalctl -u xmtpd-api.service -n 50 --no-pager
+```
+
+## Configuring xmtpd via EnvironmentFile
+
+Example unit files include:
+
+`EnvironmentFile=/etc/xmtpd/xmtpd.env`
+
+Example xmtpd.env:
+```
+# App chain
+XMTPD_APP_CHAIN_RPC_URL=https://example-app-rpc
+XMTPD_APP_CHAIN_WSS_URL=wss://example-app-wss
+
+# Settlement chain
+XMTPD_SETTLEMENT_CHAIN_RPC_URL=https://example-settlement-rpc
+XMTPD_SETTLEMENT_CHAIN_WSS_URL=wss://example-settlement-wss
+
+# Database
+XMTPD_DB_WRITER_CONNECTION_STRING=postgres://user:pass@host:5432/db?sslmode=disable
+
+# MLS validation
+XMTPD_MLS_VALIDATION_GRPC_ADDRESS=mls-validation:50051
+```
+
+Systemd passes these values to xmtpd.

--- a/systemd/xmtpd-api.service
+++ b/systemd/xmtpd-api.service
@@ -7,8 +7,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-EnvironmentFile=/etc/xmtpd.env
-ExecStart=/usr/local/bin/xmtpd --reflection.enable --replication.enable --log.log-level=debug --api.port=5050
+EnvironmentFile=/etc/xmtpd/xmtpd.env
+ExecStart=/usr/local/bin/xmtpd --reflection.enable --api.enable --log.log-level=debug --api.port=5050 --contracts.config-file-path=/etc/xmtpd/testnet.json
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/xmtpd-prune.service
+++ b/systemd/xmtpd-prune.service
@@ -7,7 +7,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-EnvironmentFile=/etc/xmtpd.env
+EnvironmentFile=/etc/xmtpd/xmtpd.env
 ExecStart=/usr/local/bin/xmtpd-prune
 
 [Install]

--- a/systemd/xmtpd-worker.service
+++ b/systemd/xmtpd-worker.service
@@ -7,8 +7,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-EnvironmentFile=/etc/xmtpd.env
-ExecStart=/usr/local/bin/xmtpd --indexer.enable --sync.enable --api.port=5060 --api.http-port=5065
+EnvironmentFile=/etc/xmtpd/xmtpd.env
+ExecStart=/usr/local/bin/xmtpd --indexer.enable --sync.enable --payer-report.enable --contracts.config-file-path=/etc/xmtpd/testnet.json
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add SystemD README and Docker sandbox by introducing build/run scripts, a systemd Dockerfile using Ubuntu 24.04 with xmtpd v1.0.0, and updated systemd units for API, worker, and prune services
Introduce `dev/docker/build-systemd`, `dev/docker/run-systemd`, and `dev/docker/systemd.Dockerfile` to build and run a systemd sandbox with xmtpd v1.0.0; add [README.md](https://github.com/xmtp/xmtpd-infrastructure/pull/57/files#diff-e15d3426c4047cc6e528d03209f8a8f43d2e717885fa94402c06a0d75213b109); and update systemd units to use `/etc/xmtpd/xmtpd.env` and new flags.

#### 📍Where to Start
Start with the Docker image definition in [systemd.Dockerfile](https://github.com/xmtp/xmtpd-infrastructure/pull/57/files#diff-113639288de30a500ccf53c221244c9ac7f4d63f898b98cc9f94893aa15b0e53), then review the run script in [run-systemd](https://github.com/xmtp/xmtpd-infrastructure/pull/57/files#diff-f52f63ef6fc19fd5cf5cddb474db400f43280dbd7ec24b8342cd57a87b2db9cd) and the unit changes beginning with [xmtpd-api.service](https://github.com/xmtp/xmtpd-infrastructure/pull/57/files#diff-c67495a88fcb22ced6730a35ef2628922bdd82177fe1f7fa59781965a045a286).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 36553a3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->