### PR TITLE
Wire XMTPD_DB_NAME_OVERRIDE across Helm and Terraform; add migration runbook

### DIFF
--- a/doc/runbooks/migrate-sha-db-name.md
+++ b/doc/runbooks/migrate-sha-db-name.md
@@ -1,0 +1,175 @@
+# Runbook: Migrate from SHA-based database name to a fixed name
+
+## Background
+
+Older versions of xmtpd automatically named the node's database using a Keccak256 hash of the node's private key and the settlement chain node registry address, producing names like `xmtpd_a3f2c10d9e8b`. This naming scheme has several drawbacks:
+
+- The name is opaque — you cannot tell which node owns which database by looking at it.
+- Rotating the node's private key changes the derived name, silently leaving the old data behind.
+- Infrastructure tooling (monitoring, backups) cannot predict the name in advance.
+
+As of xmtpd v0.1.0, the hash-based fallback has been removed. The database name is now sourced exclusively from:
+
+1. `XMTPD_DB_NAME_OVERRIDE` (env var / `--db.name-override` flag), or
+2. The database name embedded in `XMTPD_DB_WRITER_CONNECTION_STRING` if the override is not set.
+
+This runbook covers migrating a running node from the old `xmtpd_<sha>` name to a fixed name (e.g. `xmtpddata`) without data loss.
+
+---
+
+## Prerequisites
+
+- Direct SQL access to the node's PostgreSQL instance (Aurora writer endpoint, or equivalent).
+- The ability to update the node's environment variables and restart it.
+- A maintenance window is recommended but not strictly required — `ALTER DATABASE … RENAME` is a metadata-only operation and completes instantly.
+
+---
+
+## Step 1 — Identify the current database name
+
+Connect to the node's PostgreSQL instance and run:
+
+```sql
+SELECT datname FROM pg_database WHERE datname LIKE 'xmtpd_%';
+```
+
+You should see exactly one row, e.g.:
+
+```
+      datname
+-------------------
+ xmtpd_a3f2c10d9e8b
+```
+
+Note this name — you will need it in Step 3.
+
+If there is also a `xmtpddata` row, it is an empty placeholder database created by your cloud provider at cluster provisioning time. Verify it is empty before proceeding:
+
+```sql
+\c xmtpddata
+\dt
+-- Expected: "Did not find any relations."
+```
+
+---
+
+## Step 2 — Configure the fixed database name
+
+Set `XMTPD_DB_NAME_OVERRIDE` to your chosen fixed name (e.g. `xmtpddata`) in your deployment configuration **before** restarting the node.
+
+### Kubernetes (Helm)
+
+In your `values.yaml`:
+
+```yaml
+databaseName: "xmtpddata"
+```
+
+This propagates to all xmtpd pods (api, sync, indexer, reporting) and the prune CronJob automatically.
+
+### AWS Terraform
+
+In your module calls:
+
+```hcl
+module "xmtpd_api" {
+  source  = "..."
+  db_name = "xmtpddata"
+  # ...
+}
+
+module "xmtpd_worker" {
+  source  = "..."
+  db_name = "xmtpddata"
+  # ...
+}
+
+module "xmtpd_prune" {
+  source  = "..."
+  db_name = "xmtpddata"
+  # ...
+}
+```
+
+**Do not apply or restart yet** — do the database rename in Step 3 first.
+
+---
+
+## Step 3 — Rename the database
+
+While the node is still running (or after stopping it), execute the rename on the PostgreSQL writer endpoint.
+
+If an empty `xmtpddata` placeholder exists, drop it first:
+
+```sql
+DROP DATABASE xmtpddata;
+```
+
+Then rename:
+
+```sql
+ALTER DATABASE "xmtpd_a3f2c10d9e8b" RENAME TO "xmtpddata";
+```
+
+Replace `xmtpd_a3f2c10d9e8b` with the actual name found in Step 1.
+
+> **Note:** `ALTER DATABASE … RENAME` requires that no other sessions are connected to the database being renamed. If connections are open, terminate them first:
+>
+> ```sql
+> SELECT pg_terminate_backend(pid)
+> FROM pg_stat_activity
+> WHERE datname = 'xmtpd_a3f2c10d9e8b'
+>   AND pid <> pg_backend_pid();
+> ```
+
+---
+
+## Step 4 — Apply the configuration and restart
+
+Deploy the updated configuration from Step 2. The node will restart and connect to `xmtpddata`.
+
+### Kubernetes
+
+```sh
+helm upgrade <release-name> ./helm/xmtpd -f your-values.yaml
+```
+
+### AWS Terraform
+
+```sh
+terraform apply
+```
+
+ECS will drain the old task and start a new one with `XMTPD_DB_NAME_OVERRIDE=xmtpddata`.
+
+---
+
+## Step 5 — Verify
+
+Check the node logs for a successful connection message:
+
+```
+{"level":"info","msg":"successfully connected to database","namespace":"xmtpddata"}
+```
+
+Confirm the node is healthy and replicating:
+
+```sh
+# Kubernetes
+kubectl logs -l app.kubernetes.io/role=xmtpd-server-api --tail=50
+
+# AWS (CloudWatch)
+aws logs tail /ecs/xmtpd-api --follow
+```
+
+---
+
+## Rollback
+
+If the node fails to start after the rename, rename the database back and redeploy the previous image:
+
+```sql
+ALTER DATABASE "xmtpddata" RENAME TO "xmtpd_a3f2c10d9e8b";
+```
+
+Then remove `XMTPD_DB_NAME_OVERRIDE` from your config and redeploy.

--- a/doc/runbooks/migrate-sha-db-name.md
+++ b/doc/runbooks/migrate-sha-db-name.md
@@ -8,7 +8,7 @@ Older versions of xmtpd automatically named the node's database using a Keccak25
 - Rotating the node's private key changes the derived name, silently leaving the old data behind.
 - Infrastructure tooling (monitoring, backups) cannot predict the name in advance.
 
-As of xmtpd v0.1.0, the hash-based fallback has been removed. The database name is now sourced exclusively from:
+As of xmtpd v1.4.0, the hash-based fallback has been removed. The database name is now sourced exclusively from:
 
 1. `XMTPD_DB_NAME_OVERRIDE` (env var / `--db.name-override` flag), or
 2. The database name embedded in `XMTPD_DB_WRITER_CONNECTION_STRING` if the override is not set.
@@ -105,7 +105,38 @@ If an empty `xmtpddata` placeholder exists, drop it first:
 DROP DATABASE xmtpddata;
 ```
 
-Then rename:
+`ALTER DATABASE … RENAME` requires that **no other sessions are connected** to the database being renamed. Follow the sub-steps below carefully.
+
+### 3a — Connect to a different database
+
+You cannot be connected to the database you are renaming. Connect to the `postgres` maintenance database instead:
+
+```sh
+psql -d postgres
+```
+
+### 3b — Kill all connections to the target database
+
+```sql
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE datname = 'xmtpd_a3f2c10d9e8b'
+  AND pid <> pg_backend_pid();
+```
+
+This terminates all other sessions connected to that database.
+
+### 3c — (Optional but safer) Prevent new connections
+
+If something is aggressively reconnecting (common with app servers, ECS tasks, or pgBouncer), block new connections before renaming:
+
+```sql
+ALTER DATABASE xmtpd_a3f2c10d9e8b WITH ALLOW_CONNECTIONS false;
+```
+
+Then rerun the terminate query from 3b to catch any sessions that connected in the gap.
+
+### 3d — Rename the database
 
 ```sql
 ALTER DATABASE "xmtpd_a3f2c10d9e8b" RENAME TO "xmtpddata";
@@ -113,14 +144,17 @@ ALTER DATABASE "xmtpd_a3f2c10d9e8b" RENAME TO "xmtpddata";
 
 Replace `xmtpd_a3f2c10d9e8b` with the actual name found in Step 1.
 
-> **Note:** `ALTER DATABASE … RENAME` requires that no other sessions are connected to the database being renamed. If connections are open, terminate them first:
->
-> ```sql
-> SELECT pg_terminate_backend(pid)
-> FROM pg_stat_activity
-> WHERE datname = 'xmtpd_a3f2c10d9e8b'
->   AND pid <> pg_backend_pid();
-> ```
+### 3e — Re-enable connections (if you ran 3c)
+
+```sql
+ALTER DATABASE xmtpddata WITH ALLOW_CONNECTIONS true;
+```
+
+### Common gotchas
+
+- **Connection pools** (pgBouncer, app servers) may immediately reconnect — use `ALLOW_CONNECTIONS false` to prevent this.
+- You need **superuser** (or at minimum `CREATEDB`) privileges to rename a database.
+- **Background jobs, migration runners, and ECS tasks** can reconnect between terminate and rename — the `ALLOW_CONNECTIONS false` guard is the safest way to close that race.
 
 ---
 

--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+            - name: XMTPD_DB_NAME_OVERRIDE
+              value: {{ .Values.databaseName }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/api.yaml
+++ b/helm/xmtpd/templates/api.yaml
@@ -44,7 +44,7 @@ spec:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
             - name: XMTPD_DB_NAME_OVERRIDE
-              value: {{ .Values.databaseName }}
+              value: {{ .Values.databaseName | quote }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/cronjob.yaml
+++ b/helm/xmtpd/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
                 - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
                   value: /etc/xmtp/contracts.json
                 - name: XMTPD_DB_NAME_OVERRIDE
-                  value: {{ .Values.prune.databaseName | default .Values.databaseName }}
+                  value: {{ .Values.prune.databaseName | default .Values.databaseName | quote }}
                 {{ include "helpers.list-env-variables" . | indent 16 }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}

--- a/helm/xmtpd/templates/cronjob.yaml
+++ b/helm/xmtpd/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
                 - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
                   value: /etc/xmtp/contracts.json
                 - name: XMTPD_DB_NAME_OVERRIDE
-                  value: {{ .Values.prune.databaseName }}
+                  value: {{ .Values.prune.databaseName | default .Values.databaseName }}
                 {{ include "helpers.list-env-variables" . | indent 16 }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}

--- a/helm/xmtpd/templates/indexer.yaml
+++ b/helm/xmtpd/templates/indexer.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+            - name: XMTPD_DB_NAME_OVERRIDE
+              value: {{ .Values.databaseName }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/indexer.yaml
+++ b/helm/xmtpd/templates/indexer.yaml
@@ -44,7 +44,7 @@ spec:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
             - name: XMTPD_DB_NAME_OVERRIDE
-              value: {{ .Values.databaseName }}
+              value: {{ .Values.databaseName | quote }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/reporting.yaml
+++ b/helm/xmtpd/templates/reporting.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+            - name: XMTPD_DB_NAME_OVERRIDE
+              value: {{ .Values.databaseName }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/reporting.yaml
+++ b/helm/xmtpd/templates/reporting.yaml
@@ -44,7 +44,7 @@ spec:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
             - name: XMTPD_DB_NAME_OVERRIDE
-              value: {{ .Values.databaseName }}
+              value: {{ .Values.databaseName | quote }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
+            - name: XMTPD_DB_NAME_OVERRIDE
+              value: {{ .Values.databaseName }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/templates/sync.yaml
+++ b/helm/xmtpd/templates/sync.yaml
@@ -44,7 +44,7 @@ spec:
             - name: XMTPD_CONTRACTS_CONFIG_FILE_PATH
               value: /etc/xmtp/contracts.json
             - name: XMTPD_DB_NAME_OVERRIDE
-              value: {{ .Values.databaseName }}
+              value: {{ .Values.databaseName | quote }}
           {{- if (include "helpers.list-env-variables" .) }}
             {{ include "helpers.list-env-variables" . | indent 12 }}
           {{- end }}

--- a/helm/xmtpd/values.yaml
+++ b/helm/xmtpd/values.yaml
@@ -85,6 +85,11 @@ secret:
 
 contractsConfig: {}
 
+# Override the database name used by all xmtpd services.
+# When empty, xmtpd uses the database name from the connection string.
+# Set this to migrate away from the legacy auto-generated xmtpd_<sha> name.
+databaseName: ""
+
 env:
   secret: {}
 

--- a/terraform/aws/xmtpd-api/_variables.tf
+++ b/terraform/aws/xmtpd-api/_variables.tf
@@ -64,6 +64,12 @@ variable "service_secrets" {
   })
 }
 
+variable "db_name" {
+  description = "Override the database name (XMTPD_DB_NAME_OVERRIDE). When empty, xmtpd uses the database name from the connection string."
+  type        = string
+  default     = ""
+}
+
 variable "enable_debug_logs" {
   description = "Enable debug logs for XMTPD server"
 }

--- a/terraform/aws/xmtpd-api/main.tf
+++ b/terraform/aws/xmtpd-api/main.tf
@@ -34,6 +34,7 @@ module "api_task_definition" {
     "GOLOG_LOG_FMT"                     = "json"
     "XMTPD_MLS_VALIDATION_GRPC_ADDRESS" = var.service_config.validation_service_grpc_address
     "XMTPD_CONTRACTS_CONFIG_JSON"       = var.service_config.contracts_config
+    "XMTPD_DB_NAME_OVERRIDE"            = var.db_name
   }
 
   secrets = {

--- a/terraform/aws/xmtpd-prune/_variables.tf
+++ b/terraform/aws/xmtpd-prune/_variables.tf
@@ -29,6 +29,12 @@ variable "service_secrets" {
   })
 }
 
+variable "db_name" {
+  description = "Override the database name (XMTPD_DB_NAME_OVERRIDE). When empty, xmtpd uses the database name from the connection string."
+  type        = string
+  default     = ""
+}
+
 variable "enable_debug_logs" {
   description = "Enable debug logs for pruner"
 }

--- a/terraform/aws/xmtpd-prune/main.tf
+++ b/terraform/aws/xmtpd-prune/main.tf
@@ -5,6 +5,7 @@ locals {
     "GOLOG_LOG_FMT"               = "json"
     "XMTPD_LOG_ENCODING"          = "json"
     "XMTPD_CONTRACTS_CONFIG_JSON" = var.service_config.contracts_config
+    "XMTPD_DB_NAME_OVERRIDE"      = var.db_name
   }
 
   xmtp_secrets = {

--- a/terraform/aws/xmtpd-worker/_variables.tf
+++ b/terraform/aws/xmtpd-worker/_variables.tf
@@ -44,6 +44,12 @@ variable "service_secrets" {
   })
 }
 
+variable "db_name" {
+  description = "Override the database name (XMTPD_DB_NAME_OVERRIDE). When empty, xmtpd uses the database name from the connection string."
+  type        = string
+  default     = ""
+}
+
 variable "enable_debug_logs" {
   description = "Enable debug logs for XMTPD server"
 }

--- a/terraform/aws/xmtpd-worker/main.tf
+++ b/terraform/aws/xmtpd-worker/main.tf
@@ -30,6 +30,7 @@ module "task_definition" {
     "GOLOG_LOG_FMT"                     = "json"
     "XMTPD_MLS_VALIDATION_GRPC_ADDRESS" = var.service_config.validation_service_grpc_address
     "XMTPD_CONTRACTS_CONFIG_JSON"       = var.service_config.contracts_config
+    "XMTPD_DB_NAME_OVERRIDE"            = var.db_name
   }
 
   secrets = {


### PR DESCRIPTION
## Summary

Companion to xmtp/xmtpd#1901, which removed the Keccak256-based `xmtpd_<sha>` database name generation from xmtpd itself.

- **Helm** (`helm/xmtpd`): adds top-level `databaseName: ""` value, propagated as `XMTPD_DB_NAME_OVERRIDE` to all five templates (api, sync, indexer, reporting, prune). The prune-specific `prune.databaseName` still works as a per-job override and falls back to `databaseName`.
- **Terraform** (`terraform/aws/xmtpd-api`, `xmtpd-worker`, `xmtpd-prune`): adds `db_name` variable (default `""`) wired into `XMTPD_DB_NAME_OVERRIDE` env var.
- **Runbook** (`doc/runbooks/migrate-sha-db-name.md`): step-by-step guide for operators to identify the current SHA-named database, rename it, update config, and restart cleanly — with rollback instructions.

## Behavior when `db_name` / `databaseName` is left empty

No change to existing behavior. xmtpd falls back to the database name embedded in the connection string DSN. Existing deployments can upgrade without setting anything.

## Test plan

- [ ] `helm template` renders `XMTPD_DB_NAME_OVERRIDE` in all five templates when `databaseName` is set
- [ ] `helm template` renders empty string when `databaseName` is unset (backward-compatible)
- [ ] Terraform plan shows `XMTPD_DB_NAME_OVERRIDE` in task definition env when `db_name` is set
- [ ] Runbook reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `XMTPD_DB_NAME_OVERRIDE` across Helm templates and Terraform modules and add migration runbook
> - Adds a top-level `databaseName` value to the Helm chart ([values.yaml](https://github.com/xmtp/xmtpd-infrastructure/pull/64/files#diff-aec9dcf6106b30136ca17f52189907919ad7c81ea7e96e4b00f79b2bef95d942)) and propagates it as `XMTPD_DB_NAME_OVERRIDE` to the API, indexer, reporting, and sync deployments, and the prune CronJob.
> - Adds a `db_name` input variable (default `""`) to the `xmtpd-api`, `xmtpd-worker`, and `xmtpd-prune` Terraform modules and sets `XMTPD_DB_NAME_OVERRIDE` in each ECS task definition.
> - Adds a runbook ([migrate-sha-db-name.md](https://github.com/xmtp/xmtpd-infrastructure/pull/64/files#diff-f6450dac3290d003e17096f052c2d2369c82da607626a153d1fc8cddbf4c166e)) with SQL steps and a rollback procedure for migrating from SHA-derived database names to a fixed name.
> - Behavioral Change: all services now receive `XMTPD_DB_NAME_OVERRIDE` (empty string by default), which is a no-op unless the value is explicitly set.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #64 opened
>
> - Restructured database rename procedure with detailed sub-steps for connection management and added troubleshooting guidance [5780711]
> - Updated version reference for hash-based fallback removal [5780711]
> - Added `quote` filter to `XMTPD_DB_NAME_OVERRIDE` environment variable templates in Helm charts [1deb725]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d778ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->